### PR TITLE
Bump yarn from 1.21.1 to 1.22.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "yarn": "1.21.1"
+    "yarn": "1.22.4"
   }
 }


### PR DESCRIPTION
It's very meaningful for those who use Yarn 2 (Berry). Yarn 2 is configured per project, not global.
Perhaps, it may resolve the issue dependabot/dependabot-core#1297.