### PR TITLE
Removing commented code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
       - name: build library distribution
         run: ./build-lib-dist.sh
 
-#       - name: publish to npm
-#         run: ./publish-to-npm.sh
-#         env:
-#           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: publish to npm
+        run: ./publish-to-npm.sh
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Enable the automerge using a PAT so the merge commits trigger workflows
       - name: Auto-merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,39 +1,3 @@
-# name: CI
-# on:
-#   push:
-#     branches:
-#       - 'dependabot/*/yarn-*'
-# permissions:
-#   contents: write
-    
-# jobs:
-#   build:
-#     runs-on: ubuntu-latest
-
-# #     if: ${{ github.actor == 'dependabot[bot]' }}
-#     steps:
-#       - name: Checkout
-#         uses: actions/checkout@v1
-
-#       - name: Use node.js 12.x
-#         uses: actions/setup-node@v1
-#         with:
-#           node-version: "12.x"
-
-#       - name: fetch yarn repo
-#         run: bash -x fetch-yarn.sh
-
-#       - name: build library distribution
-#         run: ./build-lib-dist.sh
-
-# #       - name: publish to npm
-# #         run: ./publish-to-npm.sh
-# #         env:
-# #           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-#       - name: merge branch to master
-#         run: ./merge-to-master.sh
-
 name: Dependabot auto-merge
 on: pull_request_target
 permissions:


### PR DESCRIPTION
Removing commented code and fixing the auto-merge. When the new yarn-lib is release and dependabot creates a PR to update the yarn-lib package version. The PR creation will do the below:
1. Kick the CI workflow
2. Build the new yarn-lib package
3. Publish the newly built package to the npmjs registry 
4. Auto-merge the PR