### PR TITLE
Revert "bump: yarn to 1.22.22"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "yarn": "1.22.22"
+    "yarn": "1.22.19"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,6 @@
 # yarn lockfile v1
 
 
-yarn@1.22.22:
-  version "1.22.22"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz#ac34549e6aa8e7ead463a7407e1c7390f61a6610"
-  integrity sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==
+yarn@1.22.19:
+  version "1.22.19"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.19.tgz#4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447"


### PR DESCRIPTION
Not sure if this is the easiest way, but I think we should revert this and use dependabot to produce this update. That way we will automatically publish to npm.

Reverts dependabot/yarn-lib#56